### PR TITLE
Handle libvirt_domain_interface_meta with SR-IOV interfaces

### DIFF
--- a/libvirt_exporter.go
+++ b/libvirt_exporter.go
@@ -437,14 +437,16 @@ func CollectDomain(ch chan<- prometheus.Metric, stat libvirt.DomainStats) error 
 				break
 			}
 		}
-		ch <- prometheus.MustNewConstMetric(
-			libvirtDomainMetaInterfacesDesc,
-			prometheus.GaugeValue,
-			float64(1),
-			domainName,
-			SourceBridge,
-			iface.Name,
-			VirtualInterface)
+		if SourceBridge != "" || VirtualInterface != "" {
+			ch <- prometheus.MustNewConstMetric(
+				libvirtDomainMetaInterfacesDesc,
+				prometheus.GaugeValue,
+				float64(1),
+				domainName,
+				SourceBridge,
+				iface.Name,
+				VirtualInterface)
+		}
 		if iface.RxBytesSet {
 			ch <- prometheus.MustNewConstMetric(
 				libvirtDomainInterfaceRxBytesDesc,


### PR DESCRIPTION
This pull request changes the way that we report the `libvirt_domain_interface_meta` metric so that it is only present if the `SourceBridge` or `VirtualInterface` are present. In systems which use SR-IOV, there is no concept of a bridge or virtual interface, as the interface is completely passed through to the hypervisor.

This resolves a problem where the exporter would fail on a domain which has an SR-IOV enabled interface with with the following error:

```
An error has occurred while serving metrics:

collected metric "libvirt_domain_interface_meta" { label:<name:"domain" value:"host" > label:<name:"source_bridge" value:"" > label:<name:"target_device" value:"" > label:<name:"virtual_interface" value:"" > gauge:<value:1 > } was collected before with the same name and label values
```