### PR TITLE
Export version information (qemu and libvirt)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.1] - 2021-04-21
+### Added
+- Add libvirt_versions_info metric.
+
 ## [2.1.0] - 2021-04-12
 ### Added
 - Add delay time metric. Exposed to vm as a steal time.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [2.1.1] - 2021-04-21
 ### Added
 - Add libvirt_versions_info metric.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ libvirt_domain_memory_stats_unused_bytes{domain="..."}
 libvirt_domain_memory_stats_usable_bytes{domain="..."}
 libvirt_domain_memory_stats_used_percent{domain="..."}
 
-libvirt_version_info{hypervisor="...",library="..."}
+libvirt_versions_info{hypervisor_running="...",libvirtd_running="...",libvirt_library="..."}
 libvirt_up
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ libvirt_domain_memory_stats_unused_bytes{domain="..."}
 libvirt_domain_memory_stats_usable_bytes{domain="..."}
 libvirt_domain_memory_stats_used_percent{domain="..."}
 
+libvirt_version_info{hypervisor="...",library="..."}
 libvirt_up
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,6 @@ go 1.12
 require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/prometheus/client_golang v1.1.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	libvirt.org/libvirt-go v7.2.0+incompatible

--- a/libvirt_exporter.go
+++ b/libvirt_exporter.go
@@ -677,13 +677,13 @@ func CollectFromLibvirt(ch chan<- prometheus.Metric, uri string) error {
 	if err != nil {
 		return err
 	}
-	qemuVersion := fmt.Sprintf("%d.%d.%d", qemuVersionNum/1000000%10, qemuVersionNum/1000%10, qemuVersionNum%10)
+	qemuVersion := fmt.Sprintf("%d.%d.%d", qemuVersionNum/1000000%1000, qemuVersionNum/1000%1000, qemuVersionNum%1000)
 
 	libvirtVersionNum, err := conn.GetLibVersion()
 	if err != nil {
 		return err
 	}
-	libvirtVersion := fmt.Sprintf("%d.%d.%d", libvirtVersionNum/1000000%10, libvirtVersionNum/1000%10, libvirtVersionNum%10)
+	libvirtVersion := fmt.Sprintf("%d.%d.%d", libvirtVersionNum/1000000%1000, libvirtVersionNum/1000%1000, libvirtVersionNum%1000)
 
 	ch <- prometheus.MustNewConstMetric(
 		libvirtVersionInfoDesc,

--- a/libvirt_exporter.go
+++ b/libvirt_exporter.go
@@ -40,7 +40,7 @@ var (
 	libvirtVersionsInfoDesc = prometheus.NewDesc(
 		prometheus.BuildFQName("libvirt", "", "versions_info"),
 		"Versions of virtualization components",
-		[]string{"hypervisor_running_version", "libvirtd_running_version", "library_version"},
+		[]string{"hypervisor_running", "libvirtd_running", "libvirt_library"},
 		nil)
 	libvirtDomainInfoMetaDesc = prometheus.NewDesc(
 		prometheus.BuildFQName("libvirt", "domain_info", "meta"),
@@ -685,7 +685,7 @@ func CollectFromLibvirt(ch chan<- prometheus.Metric, uri string) error {
 	}
 	libvirtdVersion := fmt.Sprintf("%d.%d.%d", libvirtdVersionNum/1000000%1000, libvirtdVersionNum/1000%1000, libvirtdVersionNum%1000)
 
-	libraryVersionNum, err := libvirt.GetVersion() // virGetVersion, version of library, i.e. libvirt library used here, not the daemon
+	libraryVersionNum, err := libvirt.GetVersion() // virGetVersion, version of libvirt (dynamic) library used by this binary (exporter), not the daemon version
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
It would be nice to export some metadata of the virtualization components (QEMU - the hypervisor, Libvirt - the library) apart from the domain stats. Label naming may seem weird but we can change it.
`virsh -c qemu:///system version --daemon` - ran this command, exporter seems to work fine with the new metric
Methodology - https://libvirt.org/html/libvirt-libvirt-host.html#virConnectGetLibVersion