### PR TITLE
Added multi-stage build, bumped alpine and libxml versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM golang:1.17.3-alpine3.14
+FROM golang:1.17.3-alpine3.15 AS build
 
 ENV LIBVIRT_EXPORTER_PATH=/libvirt-exporter
-ENV LIBXML2_VER=2.9.8
+ENV LIBXML2_VER=2.9.12
 
 RUN apk add ca-certificates g++ git libnl-dev linux-headers make libvirt-dev libvirt && \
     wget ftp://xmlsoft.org/libxml2/libxml2-${LIBXML2_VER}.tar.gz -P /tmp && \
@@ -16,4 +16,9 @@ COPY . .
 
 RUN go build -mod vendor
 
-ENTRYPOINT [ "./libvirt-exporter" ]
+FROM alpine:3.15
+RUN apk add ca-certificates libvirt
+COPY --from=build $LIBVIRT_EXPORTER_PATH/libvirt-exporter /
+EXPOSE 9177
+
+ENTRYPOINT [ "/libvirt-exporter" ]


### PR DESCRIPTION
Hey there,

first, it took me two full days to figure out that yours is the only usable implementation of a libvirt-exporter ;)

With so much effort spent I wanted to contribute a tiny improvement to reduce the docker image from (uncompressed) 718 to 78 MB. Maybe it helps to improve your images pull count ;)

Regards
Stefan