### PR TITLE
Fix domain GetVcpus()

### DIFF
--- a/vendor/libvirt.org/go/libvirt/domain.go
+++ b/vendor/libvirt.org/go/libvirt/domain.go
@@ -1929,6 +1929,9 @@ func (d *Domain) GetVcpus() ([]DomainVcpuInfo, error) {
 	}
 
 	nvcpus := int(cdominfo.nrVirtCpu)
+	if nvcpus == 0 {
+		return []DomainVcpuInfo{}, nil
+	}
 	npcpus := int(cnodeinfo.nodes * cnodeinfo.sockets * cnodeinfo.cores * cnodeinfo.threads)
 	maplen := ((npcpus + 7) / 8)
 	ccpumaps := make([]C.uchar, maplen*nvcpus)


### PR DESCRIPTION
A domain might not be running, thus returning zero vCPUs. Bail out early because a zero length array cannot be passed to the underlying libvirt function.